### PR TITLE
Fix default export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
   "presets": ["es2015"],
-  "plugins": ["transform-runtime"]
+  "plugins": [
+    "add-module-exports",
+    "transform-runtime"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "ava": "^0.11.0",
     "babel-cli": "^6.4.0",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-transform-runtime": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
     "nyc": "^5.3.0",


### PR DESCRIPTION
Contrary to documentation, `require('identifierfy')` returned an exports object rather than the `identifierfy` function.
