### PR TITLE
Remove Babel, fixes #35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
   - "6"
+  - "8"
+  - "10"
 script: npm test
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # identifierfy
 
-Rewrites an identifier string so it's valid according to ES2015. Tested with
-Node.js 0.10 and above.
+Rewrites an identifier string so it's valid according to ES2015. Works in
+**Node.js 6** and above.
 
 Please see [this awesome article by Mathias
 Bynens](https://mathiasbynens.be/notes/javascript-identifiers-es6) for

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict'
 const { keyword } = require('esutils')
 
 // Follow Babel's implementation:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const { keyword } = require('esutils')
+const {keyword} = require('esutils')
 
 // Follow Babel's implementation:
 // <https://github.com/babel/babel/blob/add96d626d98133e26f62ec4c2aeee655bed069a/packages/babel-types/src/validators.js#L153:L164>
@@ -8,7 +8,7 @@ function isValidIdentifier (name) {
 }
 
 // Rewrite the name until it forms a valid identifier.
-module.exports = function identifierfy (name, { prefixInvalidIdentifiers = true, prefixReservedWords = true } = {}) {
+module.exports = function identifierfy (name, {prefixInvalidIdentifiers = true, prefixReservedWords = true} = {}) {
   // Start with a valid character. This way if the first character in the name
   // is not allowed to be used as the first character it can be prefixed with
   // an underscore, without having to be dropped. The same goes for if the name
@@ -50,7 +50,8 @@ module.exports = function identifierfy (name, { prefixInvalidIdentifiers = true,
   } else {
     const isIdentifierName = keyword.isIdentifierNameES6(withoutPrefix)
     const isReservedWord = keyword.isReservedWordES6(withoutPrefix, true)
-    if (!isIdentifierName && !prefixInvalidIdentifiers || isReservedWord && !prefixReservedWords) {
+    if ((!isIdentifierName && !prefixInvalidIdentifiers) ||
+        (isReservedWord && !prefixReservedWords)) {
       return withoutPrefix
     } else {
       return intermediate

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { keyword } from 'esutils'
+const { keyword } = require('esutils')
 
 // Follow Babel's implementation:
 // <https://github.com/babel/babel/blob/add96d626d98133e26f62ec4c2aeee655bed069a/packages/babel-types/src/validators.js#L153:L164>
@@ -7,7 +7,7 @@ function isValidIdentifier (name) {
 }
 
 // Rewrite the name until it forms a valid identifier.
-export default function identifierfy (name, { prefixInvalidIdentifiers = true, prefixReservedWords = true } = {}) {
+module.exports = function identifierfy (name, { prefixInvalidIdentifiers = true, prefixReservedWords = true } = {}) {
   // Start with a valid character. This way if the first character in the name
   // is not allowed to be used as the first character it can be prefixed with
   // an underscore, without having to be dropped. The same goes for if the name

--- a/package.json
+++ b/package.json
@@ -2,17 +2,13 @@
   "name": "identifierfy",
   "version": "1.1.1",
   "description": "Rewrites an identifier string so its valid according to ES2015",
-  "main": "dist/index.js",
+  "main": "index.js",
   "files": [
-    "dist",
-    "src"
+    "index.js"
   ],
   "scripts": {
-    "clean": "rimraf dist coverage",
-    "prebuild": "npm run clean",
-    "build": "babel src --out-dir dist --source-maps",
-    "prepublish": "npm run build",
-    "coverage": "npm run build -- --plugins istanbul && nyc npm test",
+    "clean": "rimraf coverage",
+    "coverage": "nyc npm test",
     "test": "ava",
     "posttest": "as-i-preach"
   },
@@ -34,26 +30,11 @@
   "devDependencies": {
     "@novemberborn/as-i-preach": "^6.0.0",
     "ava": "^0.17.0",
-    "babel-cli": "^6.4.0",
-    "babel-plugin-add-module-exports": "^0.2.0",
-    "babel-plugin-istanbul": "^4.1.1",
-    "babel-plugin-transform-runtime": "^6.4.0",
-    "babel-preset-es2015": "^6.3.13",
     "nyc": "^11.0.0",
     "rimraf": "^2.5.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.3.19",
     "esutils": "^2.0.2"
-  },
-  "babel": {
-    "presets": [
-      "es2015"
-    ],
-    "plugins": [
-      "add-module-exports",
-      "transform-runtime"
-    ]
   },
   "greenkeeper": {
     "ignore": [
@@ -62,7 +43,7 @@
     ]
   },
   "nyc": {
-    "instrument": false,
+    "instrument": true,
     "reporter": [
       "lcov",
       "html",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/novemberborn/identifierfy#readme",
   "devDependencies": {
     "@novemberborn/as-i-preach": "^6.0.0",
-    "ava": "^0.17.0",
+    "ava": "^0.25.0",
     "nyc": "^11.0.0",
     "rimraf": "^2.5.0"
   },
@@ -41,8 +41,7 @@
   },
   "greenkeeper": {
     "ignore": [
-      "@novemberborn/as-i-preach",
-      "ava"
+      "@novemberborn/as-i-preach"
     ]
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.1",
   "description": "Rewrites an identifier string so its valid according to ES2015",
   "main": "index.js",
+  "engines": {
+    "node": ">= 6"
+  },
   "files": [
     "index.js"
   ],

--- a/package.json
+++ b/package.json
@@ -31,18 +31,13 @@
   },
   "homepage": "https://github.com/novemberborn/identifierfy#readme",
   "devDependencies": {
-    "@novemberborn/as-i-preach": "^6.0.0",
+    "@novemberborn/as-i-preach": "^11.0.0",
     "ava": "^0.25.0",
     "nyc": "^11.0.0",
     "rimraf": "^2.5.0"
   },
   "dependencies": {
     "esutils": "^2.0.2"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "@novemberborn/as-i-preach"
-    ]
   },
   "nyc": {
     "instrument": true,

--- a/test.js
+++ b/test.js
@@ -1,23 +1,23 @@
 import test from 'ava'
 
-import identifierfy from './'
+import identifierfy from '.'
 
 test('prefixes reserved words with an underscore', t => {
   t.is(identifierfy('class'), '_class')
-  t.is(identifierfy('class', { prefixInvalidIdentifiers: false }), '_class')
+  t.is(identifierfy('class', {prefixInvalidIdentifiers: false}), '_class')
 })
 
 test('does not prefix reserved words with an underscore, if directed', t => {
-  t.is(identifierfy('class', { prefixReservedWords: false }), 'class')
+  t.is(identifierfy('class', {prefixReservedWords: false}), 'class')
 })
 
 test('prefixes characters that cannot start as an identifier with an underscore', t => {
   t.is(identifierfy('42'), '_42')
-  t.is(identifierfy('42', { prefixReservedWords: false }), '_42')
+  t.is(identifierfy('42', {prefixReservedWords: false}), '_42')
 })
 
 test('does not prefix characters that cannot start as an identifier with an underscore, if directed', t => {
-  t.is(identifierfy('42', { prefixInvalidIdentifiers: false }), '42')
+  t.is(identifierfy('42', {prefixInvalidIdentifiers: false}), '42')
 })
 
 test('leaves good names as-is', t => {


### PR DESCRIPTION
I was just checking the `npm ls` for choojs/bankai and noticed the same thing as @nicknikolov, so here's a PR to remove babel-runtime :)

Besides dropping Babel and requiring Node 6, it also updates Ava and as-i-preach, which I guess were outdated because new versions don't support Node <6.

Thanks!